### PR TITLE
Added Null-Checks for EXILED Custom Roles, and ECR Auto-updater

### DIFF
--- a/UncomplicatedCustomTeams/API/Features/ExiledCustomRole.cs
+++ b/UncomplicatedCustomTeams/API/Features/ExiledCustomRole.cs
@@ -20,7 +20,7 @@ namespace UncomplicatedCustomTeams.API.Features
         public int Id { get; set; }
 
         [YamlIgnore]
-        public string Name => CustomRole.Name;
+        public string Name => CustomRole.Name ?? "Unknown Role";
 
         [YamlIgnore]
         public RoleTypeId Role => CustomRole.Role;

--- a/UncomplicatedCustomTeams/Config.cs
+++ b/UncomplicatedCustomTeams/Config.cs
@@ -10,5 +10,8 @@ namespace UncomplicatedCustomTeams
 
         [Description("Do enable the developer (debug) mode?")]
         public bool Debug { get; set; } = false;
+
+        [Description("How long to wait for Exiled CustomRoles to be registered before checking for registry?")]
+        public float ExiledCustomRoleCheckDelay { get; set; } = 10f;
     }
 }

--- a/UncomplicatedCustomTeams/Plugin.cs
+++ b/UncomplicatedCustomTeams/Plugin.cs
@@ -25,7 +25,7 @@ namespace UncomplicatedCustomTeams
 
         public override Version RequiredExiledVersion => new(9, 4, 0);
 
-        public override PluginPriority Priority => PluginPriority.Medium;
+        public override PluginPriority Priority => PluginPriority.Higher;
 
         public static SummonedTeam NextTeam { get; set; } = null;
 

--- a/UncomplicatedCustomTeams/Utilities/ErrorManager.cs
+++ b/UncomplicatedCustomTeams/Utilities/ErrorManager.cs
@@ -5,6 +5,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Text.RegularExpressions;
 using UncomplicatedCustomTeams.API.Enums;
+using UncomplicatedCustomTeams.API.Features;
 using UnityEngine;
 
 namespace UncomplicatedCustomTeams.Utilities
@@ -245,7 +246,7 @@ namespace UncomplicatedCustomTeams.Utilities
                             return false;
                         }
 
-                        if (!roleIds.Add(role.Id))
+                        if (role is UncomplicatedCustomRole && !roleIds.Add(role.Id))
                         {
                             string message = $"Duplicate role ID {role.Id} in team {team.Name}!";
                             string suggestion = "Each role ID must be unique within its team.";

--- a/UncomplicatedCustomTeams/Utilities/FileConfigs.cs
+++ b/UncomplicatedCustomTeams/Utilities/FileConfigs.cs
@@ -1,9 +1,11 @@
 ﻿using Exiled.API.Features;
 using Exiled.Loader;
+using MEC;
 using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using UncomplicatedCustomRoles.API.Features;
 using UncomplicatedCustomTeams.API.Features;
 using UnityEngine;
 
@@ -163,6 +165,21 @@ namespace UncomplicatedCustomTeams.Utilities
                             }
                         }
 
+                        Timing.CallDelayed(10f, () =>
+                        {
+                            foreach (var role in team.EcrRoles)
+                            {
+                                if (!Exiled.CustomRoles.API.Features.CustomRole.TryGet((uint)role.Id, out var cRole))
+                                {
+                                    string warning = $"Exiled Custom Role of ID {role.Id} not found!";
+                                    string suggestion = "Ensure that the role is properly registered by its plugin in the future.";
+                                    ErrorManager.Add(file, warning, suggestion: suggestion);
+                                    LogManager.Warn($"{warning}\n{suggestion}");
+                                    team.EcrRoles.Remove(role);
+                                }
+                            }
+                        });
+
                         LogManager.Debug($"Proposed to the registerer the external team '{team.Name}' (ID: {team.Id}) from file: {file}");
                         action(team);
                     }
@@ -249,6 +266,17 @@ namespace UncomplicatedCustomTeams.Utilities
                         }
 
                         if (yamlTeam["roles"] is not List<object> rolesList)
+                        {
+                            continue;
+                        }
+
+                        if (!yamlTeam.ContainsKey("ecr_roles") || yamlTeam["ecr_roles"] == null)
+                        {
+                            LogManager.Debug($"{teamName} has no ecr_roles entry, no EXILED roles will be added. Automatically generating empty entry...");
+                            yamlTeam.Add("ecr_roles", new List<ExiledCustomRole> { new ExiledCustomRole { Id = 999, MaxPlayers = 0, Priority = API.Enums.RolePriority.Fifth } });
+                        }
+
+                        else if (yamlTeam["ecr_roles"] is not List<object> ecrRolesList)
                         {
                             continue;
                         }

--- a/UncomplicatedCustomTeams/Utilities/FileConfigs.cs
+++ b/UncomplicatedCustomTeams/Utilities/FileConfigs.cs
@@ -165,7 +165,7 @@ namespace UncomplicatedCustomTeams.Utilities
                             }
                         }
 
-                        Timing.CallDelayed(10f, () =>
+                        Timing.CallDelayed(Plugin.Instance.Config.ExiledCustomRoleCheckDelay, () =>
                         {
                             foreach (var role in team.EcrRoles)
                             {
@@ -273,7 +273,7 @@ namespace UncomplicatedCustomTeams.Utilities
                         if (!yamlTeam.ContainsKey("ecr_roles") || yamlTeam["ecr_roles"] == null)
                         {
                             LogManager.Debug($"{teamName} has no ecr_roles entry, no EXILED roles will be added. Automatically generating empty entry...");
-                            yamlTeam.Add("ecr_roles", new List<ExiledCustomRole> { new ExiledCustomRole { Id = 999, MaxPlayers = 0, Priority = API.Enums.RolePriority.Fifth } });
+                            yamlTeam.Add("ecr_roles", new List<ExiledCustomRole> { new ExiledCustomRole { Id = 999, MaxPlayers = 1, Priority = API.Enums.RolePriority.Fifth } });
                         }
 
                         else if (yamlTeam["ecr_roles"] is not List<object> ecrRolesList)


### PR DESCRIPTION
- Some amount of seconds after the plugin is initialized, it checks for whether the EXILED CustomRoles in each team are registered, and removes them if not.
- Plugin Priority changed
- If field `ecr_roles` is not found in YAML, then it is added with a dummy role. Registry will not stop if it is not there, because it is non-essential.